### PR TITLE
Improve CLI command errors

### DIFF
--- a/classeviva/cli.py
+++ b/classeviva/cli.py
@@ -1,0 +1,16 @@
+import functools
+
+from click import ClickException
+
+
+def exceptions(func):
+    """Handle application exceptions and raises them as ClickExceptions."""
+
+    @functools.wraps(func)
+    def wrapper_exceptions(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except Exception as e:
+            raise ClickException(e)
+
+    return wrapper_exceptions

--- a/classeviva/client.py
+++ b/classeviva/client.py
@@ -1,3 +1,4 @@
+import json
 import re
 from collections import namedtuple
 from datetime import date, datetime, timedelta
@@ -112,6 +113,28 @@ class Client(object):
             for g in agenda.get("agenda", [])
         ]
 
+    def list_notes(self):
+        resp = self.session.get(
+            f"{BASE_URL}/students/{self.identity.user_id}/notes/all"
+        )
+        if resp.status_code != 200:
+            raise Exception(resp.text)
+
+        print(json.dumps(resp.json(), indent=2))
+
+        return []
+
+    def list_noticeboard(self):
+        resp = self.session.get(
+            f"{BASE_URL}/students/{self.identity.user_id}/noticeboard"
+        )
+        if resp.status_code != 200:
+            raise Exception(resp.text)
+
+        print(json.dumps(resp.json(), indent=2))
+
+        return []
+
     def list_calendar(self):
         resp = self.session.get(
             f"{BASE_URL}/students/{self.identity.user_id}/calendar/all"
@@ -119,13 +142,17 @@ class Client(object):
         if resp.status_code != 200:
             raise Exception(resp.text)
 
+        print(json.dumps(resp.json(), indent=2))
+
         return []
 
     def list_cards(self):
         resp = self.session.get(
-            f"{BASE_URL}/students/{self.identity.user_id}/cards"
+            f"{BASE_URL}/students/{self.identity.user_id}/card"
         )
         if resp.status_code != 200:
             raise Exception(resp.text)
+
+        print(json.dumps(resp.json(), indent=2))
 
         return []

--- a/cli/classeviva
+++ b/cli/classeviva
@@ -5,6 +5,7 @@ from itertools import groupby
 
 import click
 
+from classeviva.cli import exceptions
 from classeviva.client import Client
 from classeviva.credentials import EnvCredentialsProvider
 
@@ -16,6 +17,7 @@ def cli():
 
 
 @cli.command("list-grades")
+@exceptions
 def list_grades():
     with Client(EnvCredentialsProvider()) as client:
         grades = client.grades()
@@ -50,6 +52,7 @@ def list_grades():
     type=click.DateTime(formats=["%Y-%m-%d"]),
     default=str(date.today() + timedelta(days=5)),
 )
+@exceptions
 def list_agenda(since: str, until: str):
     with Client(EnvCredentialsProvider()) as client:
         entries = client.list_agenda(since=since.date(), until=until.date())
@@ -69,7 +72,28 @@ def list_agenda(since: str, until: str):
                 click.echo(f"- {entry.author}, {entry.notes}")
 
 
+@cli.command("list-noticeboard")
+@exceptions
+def list_noticeboard():
+    with Client(EnvCredentialsProvider()) as client:
+        noticeboard = client.list_noticeboard()
+
+        for entry in noticeboard:
+            click.echo(entry)
+
+
+@cli.command("list-notes")
+@exceptions
+def list_notes():
+    with Client(EnvCredentialsProvider()) as client:
+        notes = client.list_notes()
+
+        for entry in notes:
+            click.echo(entry)
+
+
 @cli.command("list-calendar")
+@exceptions
 def list_calendar():
     with Client(EnvCredentialsProvider()) as client:
         calendar = client.list_calendar()
@@ -79,6 +103,7 @@ def list_calendar():
 
 
 @cli.command("list-cards")
+@exceptions
 def list_cards():
     with Client(EnvCredentialsProvider()) as client:
         cards = client.list_cards()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ REQUIRES = ["pydantic >= 1.9.0", "requests >= 2.25.1", "click >= 7.1.2"]
 setup(
     name=NAME,
     version=VERSION,
-    description="Python library and a CLI tool to access the https://web.spaggiari.eu",
+    description="Python library and a CLI tool to access the https://web.spaggiari.eu",  # noqa: E501
     author="Maurizio Branca",
     author_email="maurizio.branca@gmail.com",
     url="https://github.com/zmoog/classeviva-client",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as f:
     long_description = f.read()
 
 NAME = "classeviva-client"
-VERSION = "0.0.6"
+VERSION = "0.0.7"
 REQUIRES = ["pydantic >= 1.9.0", "requests >= 2.25.1", "click >= 7.1.2"]
 
 setup(

--- a/tests/cli/test_agenda.py
+++ b/tests/cli/test_agenda.py
@@ -16,7 +16,6 @@ cv = import_module("cv", "cli/classeviva")
     side_effect=MockResponseBuilder("cli/testdata/agenda.2022-04-05.json"),
 )
 def test_list_grades(identity_response_mock, agenda_response_mock):
-
     runner = CliRunner()
     result = runner.invoke(
         cv.cli,

--- a/tests/cli/test_exceptions.py
+++ b/tests/cli/test_exceptions.py
@@ -1,0 +1,28 @@
+from click.testing import CliRunner
+
+from tests.cli import import_module
+
+cv = import_module("cv", "cli/classeviva")
+
+
+def test_exceptions():
+    runner = CliRunner()
+    result = runner.invoke(
+        cv.cli,
+        ["list-agenda", "--since", "2022-04-05", "--until", "2022-04-05"],
+        env={
+            # Setting environment variables for credentials to a
+            # blank value is expected to cause the raise of a
+            # `CredentialsNotFoundError` exception.
+            "CLASSEVIVA_USERNAME": "",
+            "CLASSEVIVA_PASSWORD": "",
+        },
+    )
+
+    expected = (
+        "Error: Can't find credentials in the "
+        "CLASSEVIVA_* environment variables\n"
+    )
+
+    assert result.exit_code == 1
+    assert result.output == expected


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

The CLI prints the entire stack trace in the terminal every time an error occurs during commands execution. This is pretty informative, but also pretty ugly.

Right now I just want a concise error message. We can evaluate a `--debug` option with the stack trace later on.

```shell
$ unset CLASSEVIVA_USERNAME
$ classeviva list-grade
Error: Can't find credentials in the CLASSEVIVA_* environment variables
```

### Change description
<!-- What does your code do? -->

Add a `@exceptions` decorator for the command handlers that catches every `Exception` wraps it in a `ClickException` and raises it.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

Closes #7 

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are appropriately filled.
* [ ] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.